### PR TITLE
Fix: Restore YAML front matter to style.scss for Jekyll processing

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,3 +1,7 @@
+---
+sitemap: false
+---
+
 @use "variables" as *;
 
 /*


### PR DESCRIPTION
I've added the necessary YAML front matter (`---
sitemap: false
---
`) to `assets/css/style.scss`.

This ensures that Jekyll processes the SCSS file correctly and generates the corresponding CSS output, which is essential for your site's styling to be applied.